### PR TITLE
feat : 회원가입 및 로그인 구현

### DIFF
--- a/src/main/java/law/counsel/global/exception/ExceptionType.java
+++ b/src/main/java/law/counsel/global/exception/ExceptionType.java
@@ -5,13 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
@@ -29,7 +23,11 @@ public enum ExceptionType {
     ACCESS_DENIED(FORBIDDEN, "S002", "접근 권한이 없습니다."),
     JWT_EXPIRED(UNAUTHORIZED, "S003", "인증 정보가 만료되었습니다."),
     JWT_INVALID(UNAUTHORIZED, "S004", "인증 정보가 잘못되었습니다."),
-    JWT_NOT_EXIST(UNAUTHORIZED, "S005", "인증 정보가 존재하지 않습니다.");
+    JWT_NOT_EXIST(UNAUTHORIZED, "S005", "인증 정보가 존재하지 않습니다."),
+
+    // Member
+    MEMBER_ALREADY_EXISTS(CONFLICT,"M001","이미 존재하는 유저입니다."),
+    MEMBER_INFO_INVALID(CONFLICT,"M002","유저 정보가 일치하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/law/counsel/global/jwt/token/TokenUtils.java
+++ b/src/main/java/law/counsel/global/jwt/token/TokenUtils.java
@@ -1,6 +1,7 @@
 package law.counsel.global.jwt.token;
 
 import jakarta.servlet.http.HttpServletResponse;
+import law.counsel.global.jwt.token.dto.JwtPair;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +12,7 @@ public class TokenUtils {
     /**
      * AccessToken을 AUTHORIZATION 헤더에 넣습니다.
      */
-    public void setAccessToken(HttpServletResponse response, String accessToken) {
-        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken);
+    public void setAccessToken(HttpServletResponse response, JwtPair token) {
+        response.addHeader(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + token.accessToken());
     }
 }

--- a/src/main/java/law/counsel/global/jwt/token/dto/JwtPair.java
+++ b/src/main/java/law/counsel/global/jwt/token/dto/JwtPair.java
@@ -1,0 +1,10 @@
+package law.counsel.global.jwt.token.dto;
+
+public record JwtPair (
+        String accessToken,
+        int accessTokenExpiredIn
+) {
+    public static JwtPair of(String accessToken, int accessTokenExpiredIn) {
+        return new JwtPair(accessToken, accessTokenExpiredIn);
+    }
+}

--- a/src/main/java/law/counsel/global/jwt/token/dto/SignInRequest.java
+++ b/src/main/java/law/counsel/global/jwt/token/dto/SignInRequest.java
@@ -1,0 +1,15 @@
+package law.counsel.global.jwt.token.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record SignInRequest(
+        @Schema(description = "이메일 주소", example = "park@duck.com")
+        @NotBlank(message = "이메일 주소는 필수 입력 항목입니다.")
+        String email,
+
+        @Schema(description = "비밀번호")
+        @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+        String password
+) {
+}

--- a/src/main/java/law/counsel/member/Member.java
+++ b/src/main/java/law/counsel/member/Member.java
@@ -34,9 +34,12 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberType memberType;
 
-    @Column(name = "is_active")
-    private Boolean isActive;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
+    @Builder
+    public Member(Long memberId, String email, String password, MemberType memberType) {
+        this.memberId = memberId;
+        this.email = email;
+        this.password = password;
+        this.memberType = memberType;
+    }
 }

--- a/src/main/java/law/counsel/member/Member.java
+++ b/src/main/java/law/counsel/member/Member.java
@@ -1,20 +1,14 @@
 package law.counsel.member;
-
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "members")
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @Builder
 public class Member {
     @Id
@@ -36,10 +30,11 @@ public class Member {
 
 
     @Builder
-    public Member(Long memberId, String email, String password, MemberType memberType) {
+    public Member(Long memberId, String email, String password, String name, MemberType memberType) {
         this.memberId = memberId;
         this.email = email;
         this.password = password;
+        this.name = name;
         this.memberType = memberType;
     }
 }

--- a/src/main/java/law/counsel/member/controller/AuthController.java
+++ b/src/main/java/law/counsel/member/controller/AuthController.java
@@ -1,0 +1,34 @@
+package law.counsel.member.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import law.counsel.global.jwt.token.TokenUtils;
+import law.counsel.global.jwt.token.dto.JwtPair;
+import law.counsel.global.jwt.token.dto.SignInRequest;
+import law.counsel.global.response.ResponseBody;
+import law.counsel.global.response.ResponseUtil;
+import law.counsel.member.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final TokenUtils tokenUtils;
+    /*
+    로그인
+     */
+    @PostMapping("/sign-in")
+    public ResponseEntity<ResponseBody<Void>> signIn(@RequestBody SignInRequest signInRequest,
+                                                     HttpServletResponse response) {
+        JwtPair tokens = authService.signIn(signInRequest.email(), signInRequest.password());
+        tokenUtils.setAccessToken(response, tokens);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+}

--- a/src/main/java/law/counsel/member/controller/MemberController.java
+++ b/src/main/java/law/counsel/member/controller/MemberController.java
@@ -21,8 +21,8 @@ public class MemberController {
     회원 가입
      */
     @PostMapping("/sign-up")
-    public ResponseEntity<ResponseBody<String>> signIn(@RequestBody @Valid SignUpRequest signInRequest){
-        memberService.signUp(signInRequest);
+    public ResponseEntity<ResponseBody<String>> signUp(@RequestBody @Valid SignUpRequest signUpRequest){
+        memberService.signUp(signUpRequest);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("회원가입 성공"));
     }
 }

--- a/src/main/java/law/counsel/member/controller/MemberController.java
+++ b/src/main/java/law/counsel/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package law.counsel.member.controller;
+
+import jakarta.validation.Valid;
+import law.counsel.global.response.ResponseBody;
+import law.counsel.global.response.ResponseUtil;
+import law.counsel.member.dto.SignUpRequest;
+import law.counsel.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+    private final MemberService memberService;
+    /*
+    회원 가입
+     */
+    @PostMapping("/sign-up")
+    public ResponseEntity<ResponseBody<String>> signIn(@RequestBody @Valid SignUpRequest signInRequest){
+        memberService.signUp(signInRequest);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("회원가입 성공"));
+    }
+}

--- a/src/main/java/law/counsel/member/dto/SignUpRequest.java
+++ b/src/main/java/law/counsel/member/dto/SignUpRequest.java
@@ -1,0 +1,15 @@
+package law.counsel.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SignUpRequest {
+
+    @NotNull
+    private String name;
+    @NotNull
+    private String email;
+    @NotNull
+    private String password;
+}

--- a/src/main/java/law/counsel/member/repository/MemberRepository.java
+++ b/src/main/java/law/counsel/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package law.counsel.member.repository;
+
+import law.counsel.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/law/counsel/member/service/AuthService.java
+++ b/src/main/java/law/counsel/member/service/AuthService.java
@@ -1,0 +1,48 @@
+package law.counsel.member.service;
+
+
+import law.counsel.global.exception.BusinessException;
+import law.counsel.global.exception.ExceptionType;
+import law.counsel.global.jwt.JwtClaims;
+import law.counsel.global.jwt.token.access.AccessTokenData;
+import law.counsel.global.jwt.token.access.AccessTokenProvider;
+import law.counsel.global.jwt.token.dto.JwtPair;
+import law.counsel.member.Member;
+import law.counsel.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final AccessTokenProvider accessTokenProvider;
+
+
+    private final PasswordEncoder passwordEncoder;
+
+    public JwtPair signIn(String email, String password) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ExceptionType.MEMBER_INFO_INVALID));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new BusinessException(ExceptionType.MEMBER_INFO_INVALID);
+        }
+
+        // 토큰 발급
+        return generateJwtPair(member);
+    }
+
+    public JwtPair generateJwtPair(Member member) {
+        JwtClaims claims = JwtClaims.create(member);
+        AccessTokenData accessToken = accessTokenProvider.createToken(claims);
+        return JwtPair.of(accessToken.token(), accessToken.expiredIn());
+    }
+
+}

--- a/src/main/java/law/counsel/member/service/MemberService.java
+++ b/src/main/java/law/counsel/member/service/MemberService.java
@@ -1,0 +1,32 @@
+package law.counsel.member.service;
+import law.counsel.global.exception.BusinessException;
+import law.counsel.global.exception.ExceptionType;
+import law.counsel.member.Member;
+import law.counsel.member.MemberType;
+import law.counsel.member.dto.SignUpRequest;
+import law.counsel.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    public void signUp(SignUpRequest signUpRequest){
+        // 존재하는 유저인지 확인
+        if(memberRepository.findByEmail(signUpRequest.getEmail()).isPresent()){
+            throw new BusinessException(ExceptionType.MEMBER_ALREADY_EXISTS);
+        }
+        Member member = Member.builder()
+                .name(signUpRequest.getName())
+                .memberType(MemberType.USER)
+                .email(signUpRequest.getEmail())
+                .password(passwordEncoder.encode(signUpRequest.getPassword()))
+                .build();
+        memberRepository.save(member);
+
+    }
+}


### PR DESCRIPTION


## 📋 Summary
회원가입과 JWT 기반 로그인 기능을 구현했습니다.

## 🔧 Changes
- 회원가입 API 구현 (`POST /api/v1/members/sign-up`)
- JWT 로그인 API 구현 (`POST /api/v1/auth/sign-in`)
- MemberRepository 추가
- AuthService, MemberService 구현
- 새로운 DTO 추가: SignUpRequest, SignInRequest, JwtPair
- 회원 관련 예외 타입 추가

